### PR TITLE
use streamFilter for mediarecorder audio capture

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,11 @@ Or you can create a new TranslateReader in [translationReader.ts](./src/constant
 
 ## Audio record for MediaRecorder
 
-Because there is no api for capturing audio from tab output and `MediaRecorder` does not support change stream during recording, global audio is needed for audio recording. Select any window or screen and **check `Also share system audio`** when browser prompt.
+~~Because there is no api for capturing audio from tab output and `MediaRecorder` does not support change stream during recording, global audio is needed for audio recording. Select any window or screen and **check `Also share system audio`** when browser prompt.~~
+
+Audio now capture from streamFilter.
+
+> tip: use `--autoplay-policy=no-user-gesture-required` flag to allow auto play audio without user interaction in Chrome.
 
 > **Notice: all sound will be captured.**
 

--- a/src/controller/recordController.ts
+++ b/src/controller/recordController.ts
@@ -1,4 +1,5 @@
 import { OBSWebSocket } from 'obs-websocket-js';
+import { sound, filters } from "@pixi/sound";
 
 export interface IRecordController {
   start(): void;
@@ -14,8 +15,14 @@ export class MediaRecorderController implements IRecordController {
     this._recorder = recorder;
   }
 
-  public static create(stream: MediaStream, captureStream: MediaStream, mimeType: string = 'video/webm; codecs=vp9'): MediaRecorderController {
+  public static create(stream: MediaStream, mimeType: string = 'video/webm; codecs=vp9'): MediaRecorderController {
     const self = new this();
+    const captureStream = new MediaStream();
+    const streamFilter = new filters.StreamFilter();
+    streamFilter.stream.getAudioTracks().forEach((track) => {
+      captureStream.addTrack(track);
+    });
+    sound.filtersAll = [streamFilter];
     try {
       captureStream.getAudioTracks().forEach(element => {
         stream.addTrack(element);

--- a/src/index.ts
+++ b/src/index.ts
@@ -34,7 +34,7 @@ if (sv && sv.toLowerCase() === 'true') {
       // default
       recordController = MediaRecorderController.create(
         app.canvas.captureStream(24),
-        await navigator.mediaDevices.getDisplayMedia({ audio: true })
+        // await navigator.mediaDevices.getDisplayMedia({ audio: true })
       );
       break;
   }


### PR DESCRIPTION
修改了mediarocorder的音频录制方式，不再需要手动提供系统音频。现在可以在无人操作的情况下生成剧情视频。